### PR TITLE
[fix] 게시글 수정 API 로직 수정

### DIFF
--- a/src/api/imageApi.js
+++ b/src/api/imageApi.js
@@ -4,7 +4,8 @@ const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
 export const uploadPostDetail = async (postId, formData) => {
   try {
-    const token = localStorage.getItem('token');
+    // const token = localStorage.getItem('token');
+    const token = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYTYxZUBkYXVtLm5ldCIsInJvbGVzIjpbIlJPTEVfVVNFUiJdLCJpYXQiOjE3MjU5NjM0NzMsImV4cCI6MTcyNTk5OTQ3M30.ywYx9l251uzSvIsyBymCARhxu5pFq4FPl98rTi3GaBI';
 
     const response = await axios.post(
       `${API_BASE_URL}/api/posts/create-postDetail/${postId}`,
@@ -12,10 +13,13 @@ export const uploadPostDetail = async (postId, formData) => {
       {
         headers: {
           Authorization: `Bearer ${token}`,
-          'Content-Type': 'multipart/form-data',
+          'Content-Type': 'multipart/form-data'
         },
       }
     );
+
+    console.log('formData', formData);
+    console.log('formData.postDetailResponse', formData.postDetailResponse);
 
     return response.data;
   } catch (error) {

--- a/src/api/postDetailApi.js
+++ b/src/api/postDetailApi.js
@@ -7,7 +7,8 @@ const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 // 새 게시글 작성 api
 export const createPost = async (newPostData) => {
   try {
-    const token = localStorage.getItem('token');
+    // const token = localStorage.getItem('token');
+    const token = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYTYxZUBkYXVtLm5ldCIsInJvbGVzIjpbIlJPTEVfVVNFUiJdLCJpYXQiOjE3MjYwNjE5NTQsImV4cCI6MTcyNjA5Nzk1NH0.Zqdwy_EwULnBpa4esYqroAdOwVX5JgHnNVOrWm183-0';
 
     // voteRequest가 없으면 null로 설정
     const postData = {
@@ -58,15 +59,16 @@ export const getPostById = async (id) => {
 
 
 // 게시글 수정
-export const modifyPost = async (id) => {
+export const modifyPost = async (id, updatePostData) => {
   try {
-    const token = localStorage.getItem('token');
+    // const token = localStorage.getItem('token');
+    const token = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYTYxZUBkYXVtLm5ldCIsInJvbGVzIjpbIlJPTEVfVVNFUiJdLCJpYXQiOjE3MjYwNjE5NTQsImV4cCI6MTcyNjA5Nzk1NH0.Zqdwy_EwULnBpa4esYqroAdOwVX5JgHnNVOrWm183-0';
 
     const modifiedPostData = {
-      title: post.title,
-      content: post.content,
-      category: post.category,
-      voteRequest: post.voteRequest
+      title: updatePostData.title,
+      content: updatePostData.content,
+      category: updatePostData.category,
+      voteRequest: updatePostData.voteRequest
     };
 
     const response = await axios.put(
@@ -95,7 +97,8 @@ export const modifyPost = async (id) => {
 // 게시글 삭제
 export const deletePost = async (id) => {
   try {
-    const token = localStorage.getItem('token');
+    // const token = localStorage.getItem('token');
+    const token = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYTYxZUBkYXVtLm5ldCIsInJvbGVzIjpbIlJPTEVfVVNFUiJdLCJpYXQiOjE3MjYwNjE5NTQsImV4cCI6MTcyNjA5Nzk1NH0.Zqdwy_EwULnBpa4esYqroAdOwVX5JgHnNVOrWm183-0';
 
     const response = await axios.delete(`${API_BASE_URL}/api/posts/delete-post/${id}`, {
       headers: {

--- a/src/components/core/img-upload-field/ImgUploadField.jsx
+++ b/src/components/core/img-upload-field/ImgUploadField.jsx
@@ -23,6 +23,13 @@ const ImgUploadField = ({ onChange }) => {
     }
   };
 
+  // const handleImageChange = (event) => {
+  //   const file = event?.target.files[0];
+  //   if (file) {
+  //     onChange(file); // 파일 객체를 부모 컴포넌트로 전달
+  //   }
+  // };
+
   return (
     <div
       className={styles.container}

--- a/src/components/core/img-view-field/ImgPreviewField.jsx
+++ b/src/components/core/img-view-field/ImgPreviewField.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import styles from './ImgPreviewField.module.scss';
 import { Icon } from '..';
 
-const ImgPreviewField = ({ images, onRemove }) => {
+const ImgPreviewField = ({ imagePreviews, onRemove }) => {
   return (
     <ul className={styles.previewContainer}>
-      {images.map((image, index) => (
+      {imagePreviews.map((image, index) => (
         <li key={index} className={styles.previewWrap}>
           <div className={styles.icon}>
             <Icon type={'IconDelete'} onClick={() => onRemove(index)} />

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -1,13 +1,15 @@
 import React, { useContext } from 'react';
 import styles from './Header.module.scss';
 import { Icon } from '../core';
-import { useNavigate } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import { PostFormContext } from '../../contexts/PostFormContext';
 import { PopupModalContext } from '../../contexts/PopupModalContext';
 import { UserContext } from "../../contexts/UserContext";
 
 const Header = ({ type, location }) => {
   const navigate = useNavigate();
+  const { id } = useParams();
+
   // console.log(window.history);
 
   const { isEdit, addPost, updatePost } = useContext(PostFormContext);
@@ -73,7 +75,7 @@ const Header = ({ type, location }) => {
               {!isEdit ? (
                 <button onClick={addPost}>등록</button>
               ) : (
-                <button onClick={updatePost}>완료</button>
+                <button onClick={() => updatePost(id)}>완료</button>
               )}
             </div>
           </header>

--- a/src/pages/post-detail/PostDetail.jsx
+++ b/src/pages/post-detail/PostDetail.jsx
@@ -16,6 +16,7 @@ import { PopupModalContext } from '../../contexts/PopupModalContext';
 
 const PostDetail = () => {
   const { id } = useParams();
+  console.log('현재 ID:', id);
   const navigate = useNavigate();
 
   const [post, setPost] = useState(null);
@@ -28,9 +29,10 @@ const PostDetail = () => {
     const fetchPost = async () => {
       try {
         if (typeof id !== 'string') {
-          console.error('잘못된 ID 형식:', id);  // ID가 문자열이 아닌 경우 로그 출력
+          console.log('잘못된 ID 형식:', id);  // ID가 문자열이 아닌 경우 로그 출력
           return;
         }
+
         const data = await getPostById(id);
         console.log(data);
         setPost(data);
@@ -46,9 +48,10 @@ const PostDetail = () => {
   }, [id]);
 
 
-  // 게시글 수정
+  // 게시글 수정페이지로 이동
   const handleModifyPost = async () => {
     navigate(`/post/edit/${id}`, { state: { post } });
+    console.log(post)
   };
 
   if (loading) {
@@ -56,7 +59,7 @@ const PostDetail = () => {
   }
 
   if (!post) {
-    return <div>게시글을 불러오지 못했습니다.</div>;
+    return <div>게시글 수정 후 불러오지 못했습니다.</div>;
   }
 
 
@@ -104,18 +107,11 @@ const PostDetail = () => {
         </section>
 
         <section className={styles.wrap}>
-          {/* <ImgViewField src="https://cafe24img.poxo.com/dinotaeng/web/product/small/202205/b7bb570a94d0732787fc2110ec4bbe6c.png"
-            alt="Example Image"
+          <ImgViewField
+            src={''}
+            alt="게시글 이미지"
             className={styles.img}
-            onErrorSrc="https://example.com/fallback-image.svg" /> */}
-
-          {post.images && post.images.length > 0 && (
-            <ImgViewField
-              src={post.images[0]} // 첫 번째 이미지 URL을 예로 사용
-              alt="게시글 이미지"
-              className={styles.img}
-            />
-          )}
+          />
         </section>
 
         <section className={styles.wrap}>

--- a/src/pages/write-post/WritePost.jsx
+++ b/src/pages/write-post/WritePost.jsx
@@ -16,18 +16,27 @@ import { useParams } from 'react-router';
 const WritePost = () => {
   const { id } = useParams();
 
-  const { setIsEdit, setCategory, setTitle, setContent, setVoteItems, uploadWriteVote, removeVoteToPost, images, setImages, addImage, removeImage } = useContext(PostFormContext);
+  const {
+    setIsEdit,
+    setCategory,
+    setTitle,
+    setContent,
+    setVoteItems,
+    uploadWriteVote,
+    removeVoteToPost,
+    imagePreviews,
+    addImage,
+    removeImage
+  } = useContext(PostFormContext);
   const { Modal, openModalHandler } = useModal(null);
-  // const [images, setImages] = useState([]);
-
 
   useEffect(() => {
     if (id) {  // ID가 있을 경우 수정 모드
       setIsEdit(true);
       // 기존 글 데이터 가져오기
-      const fetchPostData = async (postId) => {
+      const fetchPostData = async (id) => {
         try {
-          const post = await getPostById(postId);
+          const post = await getPostById(id);
           setCategory(post.category);
           setTitle(post.title);
           setContent(post.content);
@@ -38,21 +47,9 @@ const WritePost = () => {
       };
       fetchPostData(id);
     }
+
   }, [id, setCategory, setTitle, setContent, setVoteItems]);
 
-
-  // 이미지 미리보기 설정
-  // const handleImageChange = (newImage) => {
-  //   if (images.length >= 2) {
-  //     alert("이미지는 최대 2개까지 업로드할 수 있습니다.");
-  //     return;
-  //   }
-  //   setImages((prevImages) => [...prevImages, newImage]);
-  // };
-
-  // const handleImageRemove = (index) => {
-  //   setImages((prevImages) => prevImages.filter((_, i) => i !== index));
-  // };
 
   return (
     <div className={styles.container}>
@@ -76,9 +73,9 @@ const WritePost = () => {
 
 
 
-      {images.length > 0 && (
+      {imagePreviews.length > 0 && (
         <section className={styles.imagePreview}>
-          <ImgPreview images={images} onRemove={removeImage} />
+          <ImgPreview imagePreviews={imagePreviews} onRemove={removeImage} />
         </section>
       )}
 


### PR DESCRIPTION
### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 게시글 수정 API (API : 13번) 호출 시, 수정된 데이터가 인자에 누락되어 추가함
- [x] 게시글 수정 후 완료 버튼을 눌렀을 때 페이지 ID 값이 제대로 전달되지 않는 문제 해결
  : [완료] 버튼 클릭 시, updatePost 핸들러에서 ID값 전달이 누락되어 계속 ID값이 객체형태로 가져오는 문제가 있었다.

<br>

### 앞으로 수정 해야 하는 부분

> 구현한 부분에서 수정해야 하는 내역

- 게시글 수정 시, 기존에 작성된 투표 UI를 가져오지 못하고 있음
- 이미지 수정 로직 추가해야 함


<br>

### Checklist

> PR 등록 전 확인할 점

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 예) `[feat] 로그인 페이지 추가`
- [x] assignee가 본인으로 되어있고, label은 PR 주제에 맞게 추가했는가
- [x] 작업사항, 리뷰 요청 사항을 팀원이 이해할 수 있도록 구체적으로 작성했는가
