### PR TITLE
[fix] 팝업모달 상태 수정

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -46,6 +46,7 @@ const Header = ({ type, location }) => {
           </header>
         );
 
+      // 상세페이지 헤더 : 뒤로가기+(더보기버튼)
       case "detail":
         return (
           <header className={`${styles.header} ${styles.detailHeader}`}>

--- a/src/contexts/PopupModalContext.js
+++ b/src/contexts/PopupModalContext.js
@@ -10,9 +10,7 @@ export const PopupModalProvider = ({ children }) => {
 
   const openPopupHandler = (type) => {
     setPopupType(type);
-    if (!isPopupOpen) {
-      setIsPopupOpen(true);
-    }
+    setIsPopupOpen(true);
   }
 
   const closePopupHandler = () => {

--- a/src/pages/post-detail/PostDetail.jsx
+++ b/src/pages/post-detail/PostDetail.jsx
@@ -21,7 +21,12 @@ const PostDetail = () => {
   const [post, setPost] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  const { Popup, popupType } = useContext(PopupModalContext);
+  const { Popup, popupType, closePopupHandler } = useContext(PopupModalContext);
+
+  useEffect(() => {
+    // 상세페이지 id가 바뀔 때 팝업 상태 초기화
+    closePopupHandler();
+  }, [id]);
 
   // 상세페이지 리스트
   useEffect(() => {


### PR DESCRIPTION
### 변경사항

- 게시글 상세페이지에서 팝업모달창이 한번이라도 열렸던 적이 있으면 다른 상세페이지로 이동해도 팝업모달창이 계속 렌더링되는 오류 수정 
 → 상세페이지 id가 바뀔 때 팝업 상태 초기화

<br>

### Checklist

> PR 등록 전 확인할 점

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가 예) `[feat] 로그인 페이지 추가`
- [x] assignee가 본인으로 되어있고, label은 PR 주제에 맞게 추가했는가
- [x] 작업사항, 리뷰 요청 사항을 팀원이 이해할 수 있도록 구체적으로 작성했는가
